### PR TITLE
OpenSecurity support added to built in program 'flash.lua'

### DIFF
--- a/bin/flash.lua
+++ b/bin/flash.lua
@@ -3,9 +3,9 @@ local shell = require("shell")
 local fs = require("filesystem")
 
 if not component.isAvailable("os_cardwriter") then
-  local eeprom = component.eeprom
+  eeprom = component.eeprom
 else
-  local eeprom = component.os_cardwriter
+  eeprom = component.os_cardwriter
 end
 
 local args, options = shell.parse(...)
@@ -19,12 +19,16 @@ if #args < 1 and not options.l then
 end
 
 local function printRom()
-  io.write(eeprom.get())
+  if not component.isAvailable("os_cardwriter") then
+    io.write(eeprom.get())
+  else
+    io.stderr:write("card writer cannot read EEPROM")
 end
 
 local function readRom()
   fileName = shell.resolve(args[1])
   if not options.q then
+    if not component.isAvailable("os_cardwriter") then
     if fs.exists(fileName) then
       io.write("Are you sure you want to overwrite " .. fileName .. "?\n")
       io.write("Type `y` to confirm.\n")
@@ -41,6 +45,9 @@ local function readRom()
   if not options.q then
     io.write("All done!\nThe label is '" .. eeprom.getLabel() .. "'.\n")
   end
+    else
+      io.stderr:write("card writer cannot read EEPROM")
+    end
 end
 
 local function writeRom()
@@ -75,7 +82,7 @@ local function writeRom()
       eeprom.flash(bios, label, false)
     end
     if not options.q then
-      io.write("Set label to '" .. eeprom.getLabel() .. "'.\n")
+      io.write("Set label to '" .. label .. "'.\n")
     end
   end
 

--- a/bin/flash.lua
+++ b/bin/flash.lua
@@ -12,13 +12,17 @@ if #args < 1 and not options.l then
   return
 end
 
-local function printRom()
+if not component.isAvailable("os_cardwriter") then
   local eeprom = component.eeprom
+else
+  local eeprom = component.os_cardwriter
+end
+
+local function printRom()
   io.write(eeprom.get())
 end
 
 local function readRom()
-  local eeprom = component.eeprom
   fileName = shell.resolve(args[1])
   if not options.q then
     if fs.exists(fileName) then
@@ -52,8 +56,6 @@ local function writeRom()
     until response and response:lower():sub(1, 1) == "y"
     io.write("Beginning to flash EEPROM.\n")
   end
-
-  local eeprom = component.eeprom
 
   if not options.q then
     io.write("Flashing EEPROM " .. eeprom.address .. ".\n")

--- a/bin/flash.lua
+++ b/bin/flash.lua
@@ -1,3 +1,5 @@
+-- Modified to support OpenSecurity card writer.
+
 local component = require("component")
 local shell = require("shell")
 local fs = require("filesystem")
@@ -23,28 +25,29 @@ local function printRom()
     io.write(eeprom.get())
   else
     io.stderr:write("card writer cannot read EEPROM")
+  end
 end
 
 local function readRom()
   fileName = shell.resolve(args[1])
   if not options.q then
     if not component.isAvailable("os_cardwriter") then
-    if fs.exists(fileName) then
-      io.write("Are you sure you want to overwrite " .. fileName .. "?\n")
-      io.write("Type `y` to confirm.\n")
-      repeat
-        local response = io.read()
-      until response and response:lower():sub(1, 1) == "y"
+      if fs.exists(fileName) then
+        io.write("Are you sure you want to overwrite " .. fileName .. "?\n")
+        io.write("Type `y` to confirm.\n")
+        repeat
+          local response = io.read()
+        until response and response:lower():sub(1, 1) == "y"
+      end
+      io.write("Reading EEPROM " .. eeprom.address .. ".\n" )
     end
-    io.write("Reading EEPROM " .. eeprom.address .. ".\n" )
-  end
-  local bios = eeprom.get()
-  local file = assert(io.open(fileName, "wb"))
-  file:write(bios)
-  file:close()
-  if not options.q then
-    io.write("All done!\nThe label is '" .. eeprom.getLabel() .. "'.\n")
-  end
+    local bios = eeprom.get()
+    local file = assert(io.open(fileName, "wb"))
+    file:write(bios)
+    file:close()
+    if not options.q then
+      io.write("All done!\nThe label is '" .. eeprom.getLabel() .. "'.\n")
+    end
     else
       io.stderr:write("card writer cannot read EEPROM")
     end

--- a/tmp/update-tmp.lua
+++ b/tmp/update-tmp.lua
@@ -2,13 +2,13 @@ local fs = require("filesystem")
 local shell = require("shell")
 
 if not fs.exists("/tmp/update-tmp.cfg") then
-	u = io.open("/etc/update.cfg", "r")
+  u = io.open("/etc/update.cfg", "r")
      textu = u:read()
       u:close()
 else
-	u = io.open("/tmp/update-tmp.cfg", "r")
-	 textu = u:read()
-	  u:close()
+  u = io.open("/tmp/update-tmp.cfg", "r")
+   textu = u:read()
+    u:close()
 end
 
 shell.execute("wget -f https://raw.githubusercontent.com/Shuudoushi/SecureOS/" .. textu .. "/boot/99_login.lua /boot/99_login.lua \n")
@@ -34,4 +34,5 @@ shell.execute("wget -f https://raw.githubusercontent.com/Shuudoushi/SecureOS/" .
 shell.execute("wget -f https://raw.githubusercontent.com/Shuudoushi/SecureOS/" .. textu .. "/usr/misc/greetings.txt /usr/misc/greetings.txt \n")
 shell.execute("wget -f https://raw.githubusercontent.com/Shuudoushi/SecureOS/" .. textu .. "/lib/filesystem.lua /lib/filesystem.lua \n")
 shell.execute("wget -f https://raw.githubusercontent.com/Shuudoushi/SecureOS/" .. textu .. "/bin/edit.lua /bin/edit.lua \n")
+shell.execute("wget -f https://raw.githubusercontent.com/Shuudoushi/SecureOS/" .. textu .. "/bin/flash.lua /bin/flash.lua \n")
 os.sleep(1.5)


### PR DESCRIPTION
OpenSecurity's 'card writer' block will now be used in place of the EEPROM slot in the computer case/server if found on the network.
