### PR TITLE
Added a library for table protection

### DIFF
--- a/lib/auth.lua
+++ b/lib/auth.lua
@@ -7,6 +7,7 @@ local auth = {}
 local component = require("component")
 local fs = require("filesystem")
 local sha = require("sha256")
+local libarmor = require("libarmor")
 
 
 if not fs.exists(passwdfile) then
@@ -114,4 +115,4 @@ function auth.isRoot()
   return root
 end
 
-return auth
+return libarmor.protect(auth)

--- a/lib/libarmor.lua
+++ b/lib/libarmor.lua
@@ -1,0 +1,47 @@
+local libarmor = {}
+
+function libarmor.protect(original, whitelist)
+  --create a protected proxy table
+  local proxy = {}
+  --redirecting next is the easiest way to create an iterator
+  local function redirectedNext(t, k)
+    return next(original, k)
+  end
+  local meta = {
+    --reading access is unchanged
+    __index = original,
+    --writing access is only possible if the key is in the whitelist
+    --You can create a blacklist by giving the whitelist a corresponding __index metamethod.
+    __newindex = function(_, key, value)
+      if whitelist and whitelist[key] then
+        original[key] = value
+      else
+        error("Access denied: attempted to overwrite protected table")
+      end
+    end,
+    --prohibits access to the metatable
+    __metatable = "protected",
+    --iteration without returning the protected table
+    __pairs = function()
+      return redirectedNext, proxy, nil
+    end,
+  }
+  if _VERSION <= "Lua 5.2" then
+    --ipairs metamethod needed for version 5.2 and lower
+    --Higher versions respect the __index metamethods.
+    local function redirectedINext(t, k)
+      k = k + 1
+      --Lua 5.2 behaviour: rawget
+      local value = rawget(original, k)
+      if value ~= nil then
+        return k, value
+      end
+    end
+    function meta.__ipairs()
+      return redirectedINext, proxy, 0
+    end
+  end
+  return setmetatable(proxy, meta)
+end
+
+return libarmor

--- a/lib/libarmor.lua
+++ b/lib/libarmor.lua
@@ -44,4 +44,4 @@ function libarmor.protect(original, whitelist)
   return setmetatable(proxy, meta)
 end
 
-return libarmor
+return libarmor.protect(libarmor)


### PR DESCRIPTION
Added lib/libarmor:
It can be used to protect tables against modification from the outside.
Just some examples:
-the auth library (see #42, commit is included pull request)
-the table "package.loaded" (you could replace the auth library by your own; patch not included because it needs a bigger modification than I want to do with the github.com editor)
PS: Now I didn't forget to enable the dev branch.
